### PR TITLE
baculavirt: add virt related selinux permissions

### DIFF
--- a/files/baculavirt.te
+++ b/files/baculavirt.te
@@ -58,7 +58,7 @@ allow bacula_t virtd_t:unix_stream_socket connectto;
 allow bacula_t docker_t:unix_stream_socket connectto;
 
 #============= logrotate_t ==============
-allow logrotate_t svirt_sandbox_file_t:dir read;
+allow logrotate_t svirt_sandbox_file_t:dir { read write create remove_name add_name };
 
 #============= svirt_t ==============
-allow svirt_t fixed_disk_device_t:blk_file write;
+allow svirt_t fixed_disk_device_t:blk_file { read write open };


### PR DESCRIPTION
When running virt-backup on a Windows 2012 R2 VM audit2allow reported
that the following need to be added.

allow logrotate_t svirt_sandbox_file_t:dir add_name;

allow svirt_t fixed_disk_device_t:blk_file read;

I also added related permissions to prevent further issues from coming
up.

Signed-off-by: George McCollister <george.mccollister@gmail.com>